### PR TITLE
Make Cmd+V paste screenshots into Claude Code CLI

### DIFF
--- a/check.py
+++ b/check.py
@@ -28,7 +28,7 @@ EXPECTED_SYMLINKS = {
     "~/.zsh-z.plugin.zsh": "configs/zsh/plugins/zsh-z.plugin.zsh",
 }
 
-REQUIRED_TOOLS = ["fzf", "fd", "pyenv", "rbenv", "node", "nvim", "tmux"]
+REQUIRED_TOOLS = ["fzf", "fd", "pyenv", "rbenv", "node", "nvim", "tmux", "pngpaste"]
 
 ZSH_PLUGINS = {
     "zsh-syntax-highlighting": "~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting",

--- a/configs/kitty/kitty.conf
+++ b/configs/kitty/kitty.conf
@@ -74,3 +74,12 @@ color15 #e0def4
 # === Tmux session switching (was Alacritty [[keyboard.bindings]]) ===
 map cmd+shift+n send_text all \x01)
 map cmd+shift+p send_text all \x01(
+
+# Claude Code CLI's image-clipboard paste (via pngpaste) is wired to literal
+# Ctrl+V, not kitty's own paste_from_clipboard action -- the latter only
+# injects clipboard *text* via bracketed paste, so it silently no-ops when
+# the clipboard holds an image. Send Cmd+V as the raw Ctrl+V byte (0x16)
+# instead, so Claude Code's own handler (which checks the clipboard itself)
+# fires for both text and images. If this ever breaks plain-text Cmd+V
+# pasting elsewhere, delete this line to fall back to kitty's default.
+map cmd+v send_text all \x16

--- a/deploy.py
+++ b/deploy.py
@@ -319,6 +319,11 @@ def install_kitty_apps(force=False):
         display_name="JetBrains Mono Nerd Font",
         force=force
     )
+    install_package(
+        "pngpaste",
+        display_name="pngpaste",
+        force=force
+    )
 
 
 def install_tmux_apps(force=False):


### PR DESCRIPTION
## Summary

Found while testing the kitty migration: `Cmd+V` pasted text fine but silently did nothing for screenshots (`Cmd+Ctrl+Shift+4` then `Cmd+V`), while `Ctrl+V` worked correctly.

**Root cause:** `Cmd+V` in kitty triggers kitty's own `paste_from_clipboard` action, which only knows how to inject clipboard *text* via bracketed paste — when the clipboard holds an image, it silently no-ops. Claude Code CLI's own image-clipboard handling is bound to literal `Ctrl+V` instead, and shells out to `pngpaste` to read the image directly from the system pasteboard.

Confirmed empirically on a real machine: `pbpaste -Prefer public.png` fails to extract clipboard image data at all (empty output) even though the image is genuinely there (verified via AppleScript's `the clipboard as «class PNGf»`, and via `pngpaste` once installed) — `pngpaste` is the tool actually needed here.

## Fix

- `configs/kitty/kitty.conf`: `map cmd+v send_text all \x16` sends the raw Ctrl+V byte instead of running kitty's own paste action, so Claude Code's own handler (which inspects the clipboard itself) fires for both text and images.
- `deploy.py`: install `pngpaste` alongside kitty in `install_kitty_apps()`.
- `check.py`: add `pngpaste` to `REQUIRED_TOOLS`.

## Testing

- Verified live: `Cmd+Ctrl+Shift+4` screenshot → `Cmd+V` now pastes the image into Claude Code.
- Confirmed plain-text `Cmd+V` paste still works after the remap (tested by the user after reloading kitty's config with `Ctrl+Shift+F5`).
- `./deploy.py --only kitty` correctly installs `pngpaste`.
- `./check.py` exits 0, all 34 `test_check.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)